### PR TITLE
Adding caching to core-web

### DIFF
--- a/app/api/courses/[id]/reviews/route.ts
+++ b/app/api/courses/[id]/reviews/route.ts
@@ -53,6 +53,7 @@ export async function POST(
     // Make request to backend API using the utility function
     const response = await fetchFromApi(`/courses/${id}/reviews`, {
       method: "POST",
+      cache: "no-store",
       headers: {
         "Content-Type": "application/json",
       },
@@ -111,6 +112,7 @@ export async function GET(
     const response = await fetchFromApi(
       `/courses/${id}/reviews?${queryParams}`,
       {
+        cache: "no-store",
         headers: {
           "Content-Type": "application/json",
         },
@@ -118,7 +120,11 @@ export async function GET(
     )
 
     const data = await response.json()
-    return NextResponse.json(data)
+    return NextResponse.json(data, {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    })
   } catch (error) {
     console.error("Error fetching reviews:", error)
     return NextResponse.json(

--- a/app/api/courses/[id]/route.ts
+++ b/app/api/courses/[id]/route.ts
@@ -10,7 +10,11 @@ export async function GET(
     return fetchApiData(
       `/courses/${courseCode}`,
       "Failed to fetch course",
-      `Failed to fetch course ${courseCode}:`
+      `Failed to fetch course ${courseCode}:`,
+      {
+        cache: "default",
+        fallbackCacheControl: "public, max-age=21600, stale-while-revalidate=86400",
+      }
     )
   } catch {
     return NextResponse.json(

--- a/app/api/courses/paginated/route.ts
+++ b/app/api/courses/paginated/route.ts
@@ -21,6 +21,10 @@ export async function GET(request: NextRequest) {
   return fetchApiData(
     endpoint,
     "Failed to fetch paginated courses",
-    "Failed to fetch paginated courses:"
+    "Failed to fetch paginated courses:",
+    {
+      cache: "default",
+      fallbackCacheControl: "public, max-age=21600, stale-while-revalidate=86400",
+    }
   )
 }

--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -6,7 +6,11 @@ export async function GET(request: NextRequest) {
     return await fetchApiData(
       "/courses",
       "Failed to fetch courses",
-      "Failed to fetch courses:"
+      "Failed to fetch courses:",
+      {
+        cache: "default",
+        fallbackCacheControl: "public, max-age=21600, stale-while-revalidate=86400",
+      }
     )
   } catch (error) {
     console.error("Error in GET /api/courses:", error)

--- a/app/api/courses/search/route.ts
+++ b/app/api/courses/search/route.ts
@@ -15,6 +15,10 @@ export async function GET(request: NextRequest) {
   return fetchApiData(
     `/courses/search?q=${encodeURIComponent(query)}`,
     "Failed to search courses",
-    "Failed to search courses:"
+    "Failed to search courses:",
+    {
+      cache: "default",
+      fallbackCacheControl: "public, max-age=21600, stale-while-revalidate=86400",
+    }
   )
 }

--- a/app/api/instructors/[id]/route.ts
+++ b/app/api/instructors/[id]/route.ts
@@ -10,7 +10,11 @@ export async function GET(
     return fetchApiData(
       `/instructors/${id}`,
       "Failed to fetch instructors",
-      `Failed to fetch instructors for course ${id}:`
+      `Failed to fetch instructors for course ${id}:`,
+      {
+        cache: "default",
+        fallbackCacheControl: "public, max-age=21600, stale-while-revalidate=86400",
+      }
     )
   } catch (error) {
     return NextResponse.json(

--- a/app/api/sections/[id]/route.ts
+++ b/app/api/sections/[id]/route.ts
@@ -10,7 +10,11 @@ export async function GET(
     return fetchApiData(
       `/sections/${id}`,
       "Failed to fetch sections",
-      `Failed to fetch sections for course ${id}:`
+      `Failed to fetch sections for course ${id}:`,
+      {
+        cache: "default",
+        fallbackCacheControl: "public, max-age=21600, stale-while-revalidate=86400",
+      }
     )
   } catch (error) {
     return NextResponse.json(

--- a/app/course/[id]/page.tsx
+++ b/app/course/[id]/page.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/lib/api/courses";
 import { useCart } from "@/components/cart-context";
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { BlurredHero } from "@/components/blurred-hero";
@@ -482,7 +482,7 @@ export default function CoursePage() {
     fetchReviews();
   }, [courseCode]);
 
-  const refetchReviews = async () => {
+  const refetchReviews = useCallback(async () => {
     try {
       setIsLoadingReviews(true);
       const data = await coursesApi.getReviews(courseCode, {
@@ -497,7 +497,34 @@ export default function CoursePage() {
     } finally {
       setIsLoadingReviews(false);
     }
-  };
+  }, [courseCode]);
+
+  useEffect(() => {
+    const onWindowFocus = () => {
+      void refetchReviews();
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void refetchReviews();
+      }
+    };
+
+    // Keep review data fresh without persisting it long-term.
+    const intervalId = window.setInterval(() => {
+      if (document.visibilityState === "visible") {
+        void refetchReviews();
+      }
+    }, 60_000);
+
+    window.addEventListener("focus", onWindowFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      window.removeEventListener("focus", onWindowFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.clearInterval(intervalId);
+    };
+  }, [refetchReviews]);
 
   return (
     <div

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -1,32 +1,50 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "/api"
 
+type ApiGetOptions = {
+  cache?: RequestCache
+  headers?: HeadersInit
+}
+
 class ApiClient {
   private baseUrl: string
+  private inFlightGets = new Map<string, Promise<unknown>>()
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl
   }
 
-  async get<T>(endpoint: string): Promise<T> {
+  async get<T>(endpoint: string, options: ApiGetOptions = {}): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`
-    
-    const response = await fetch(url, {
-      cache: "no-store",
-      headers: {
-        "Cache-Control": "no-cache, no-store, must-revalidate",
-        "Pragma": "no-cache",
-        "Expires": "0",
-      },
-    })
-    
-    if (!response.ok) {
-      const errorText = await response.text()
-      console.error("API Error:", response.status, response.statusText, errorText)
-      throw new Error(`API Error: ${response.status} ${response.statusText}`)
+    const cacheMode = options.cache ?? "default"
+    const requestKey = `GET:${url}:${cacheMode}`
+
+    const existing = this.inFlightGets.get(requestKey)
+    if (existing) {
+      return existing as Promise<T>
     }
-    
-    const data = await response.json()
-    return data
+
+    // Deduplicate concurrent identical GET requests while still relying on HTTP cache.
+    const requestPromise = (async () => {
+      const response = await fetch(url, {
+        cache: cacheMode,
+        headers: options.headers,
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        console.error("API Error:", response.status, response.statusText, errorText)
+        throw new Error(`API Error: ${response.status} ${response.statusText}`)
+      }
+
+      return response.json() as Promise<T>
+    })()
+
+    this.inFlightGets.set(requestKey, requestPromise as Promise<unknown>)
+    try {
+      return await requestPromise
+    } finally {
+      this.inFlightGets.delete(requestKey)
+    }
   }
 }
 

--- a/lib/api/courses.ts
+++ b/lib/api/courses.ts
@@ -1,6 +1,12 @@
 import { apiClient } from "./client"
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "/api"
+const CATALOG_CACHE_VERSION = process.env.NEXT_PUBLIC_CATALOG_CACHE_VERSION || "v1"
+
+const withCatalogCacheVersion = (endpoint: string): string => {
+  const separator = endpoint.includes("?") ? "&" : "?"
+  return `${endpoint}${separator}cv=${encodeURIComponent(CATALOG_CACHE_VERSION)}`
+}
 
 const DAY_MAP: Record<string, string> = {
   M: "Monday",
@@ -268,7 +274,12 @@ export interface SubmitReviewBody {
 
 export const coursesApi = {
   async getAllCourses(): Promise<Course[]> {
-    const response = await apiClient.get<CoursesResponse | Course[]>("/courses")
+    const response = await apiClient.get<CoursesResponse | Course[]>(
+      withCatalogCacheVersion("/courses"),
+      {
+        cache: "default",
+      },
+    )
 
     if (Array.isArray(response)) {
       return response
@@ -287,8 +298,12 @@ export const coursesApi = {
   },
 
   async searchCourses(query: string): Promise<Course[]> {
-    const endpoint = `/courses/search?q=${encodeURIComponent(query)}`
-    const response = await apiClient.get<CoursesResponse | Course[]>(endpoint)
+    const endpoint = withCatalogCacheVersion(
+      `/courses/search?q=${encodeURIComponent(query)}`,
+    )
+    const response = await apiClient.get<CoursesResponse | Course[]>(endpoint, {
+      cache: "default",
+    })
 
     if (Array.isArray(response)) {
       return dedupeCoursesByCode(response)
@@ -310,7 +325,9 @@ export const coursesApi = {
     const normalized = courseCode.trim().toLowerCase()
     const response = await apiClient.get<
       CoursesByCodeResponse | CourseOffering[]
-    >(`/courses/${encodeURIComponent(normalized)}`)
+    >(withCatalogCacheVersion(`/courses/${encodeURIComponent(normalized)}`), {
+      cache: "default",
+    })
 
     // Some environments may return the array directly
     if (Array.isArray(response)) {
@@ -330,7 +347,8 @@ export const coursesApi = {
 
   async getSectionsByCourseId(courseId: string): Promise<Section[]> {
     const response = await apiClient.get<SectionsResponse | Section[]>(
-      `/sections/${courseId}`,
+      withCatalogCacheVersion(`/sections/${courseId}`),
+      { cache: "default" },
     )
 
     if (Array.isArray(response)) {
@@ -351,7 +369,8 @@ export const coursesApi = {
 
   async getInstructorsByCourseId(courseId: string): Promise<Instructor[]> {
     const response = await apiClient.get<InstructorsResponse | Instructor[]>(
-      `/instructors/${courseId}`,
+      withCatalogCacheVersion(`/instructors/${courseId}`),
+      { cache: "default" },
     )
 
     if (Array.isArray(response)) {
@@ -388,13 +407,14 @@ export const coursesApi = {
       queryParams.append("course_code_range", params.course_code_range)
     }
 
-    // Add cache-busting timestamp to ensure fresh requests
-    queryParams.append("_t", Date.now().toString())
-
     const queryString = queryParams.toString()
-    const endpoint = `/courses/paginated?${queryString}`
+    const endpoint = withCatalogCacheVersion(
+      `/courses/paginated${queryString ? `?${queryString}` : ""}`,
+    )
 
-    const response = await apiClient.get<PaginatedCoursesResponse>(endpoint)
+    const response = await apiClient.get<PaginatedCoursesResponse>(endpoint, {
+      cache: "default",
+    })
 
     // Ensure the response has the expected structure
     if (!response || !response.data) {
@@ -429,7 +449,9 @@ export const coursesApi = {
     const queryString = queryParams.toString()
     const endpoint = `/courses/${encodeURIComponent(normalized)}/reviews${queryString ? `?${queryString}` : ""}`
 
-    const response = await apiClient.get<ReviewsResponse>(endpoint)
+    const response = await apiClient.get<ReviewsResponse>(endpoint, {
+      cache: "no-store",
+    })
     return response
   },
 

--- a/lib/api/utils.ts
+++ b/lib/api/utils.ts
@@ -19,6 +19,18 @@ export interface ApiErrorResponse {
   error: string
 }
 
+const CACHE_HEADER_ALLOWLIST = [
+  "cache-control",
+  "etag",
+  "last-modified",
+  "expires",
+  "vary",
+] as const
+
+type FetchApiDataOptions = RequestInit & {
+  fallbackCacheControl?: string
+}
+
 /**
  * Makes a fetch request to the backend API and handles errors uniformly
  */
@@ -38,10 +50,7 @@ export async function fetchFromApi(
   const url = `${apiUrl}${endpoint}`
   
   try {
-    const response = await fetch(url, {
-      cache: "no-store",
-      ...options,
-    })
+    const response = await fetch(url, options)
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => 'No error body')
@@ -83,10 +92,11 @@ export function handleApiError(
 export async function fetchApiData<T>(
   endpoint: string,
   errorMessage: string,
-  consoleContext?: string
+  consoleContext?: string,
+  options?: FetchApiDataOptions
 ): Promise<NextResponse<T | ApiErrorResponse>> {
   try {
-    const response = await fetchFromApi(endpoint)
+    const response = await fetchFromApi(endpoint, options)
     
     // Check if response has content before parsing
     const contentType = response.headers.get("content-type")
@@ -104,7 +114,18 @@ export async function fetchApiData<T>(
       throw new Error("API returned empty response")
     }
     
-    return NextResponse.json(data)
+    const responseHeaders = new Headers()
+    for (const headerName of CACHE_HEADER_ALLOWLIST) {
+      const value = response.headers.get(headerName)
+      if (value) {
+        responseHeaders.set(headerName, value)
+      }
+    }
+    if (!responseHeaders.get("cache-control") && options?.fallbackCacheControl) {
+      responseHeaders.set("cache-control", options.fallbackCacheControl)
+    }
+
+    return NextResponse.json(data, { headers: responseHeaders })
   } catch (error) {
     return handleApiError(error, errorMessage, consoleContext)
   }


### PR DESCRIPTION
Changes are summarized below: 

- Overhauled frontend data fetching so catalogue endpoints can leverage HTTP/browser caching instead of being forced to no-store, and removed accidental cache-busting patterns.
- Right now we cache for 6 hours
- Catalogue requests now use stable, cacheable GET URLs with a manual version token (NEXT_PUBLIC_CATALOG_CACHE_VERSION) so we can force-refresh globally by bumping env + redeploy.
- Reviews are kept uncached (no-store) with immediate post-submit refetch and short freshness behaviour so user-generated content stays up to date.

Overall, fewer repeat calls against our core-api instance for static catalogue data, while preserving fresh review behaviour and giving you controlled invalidation when catalogue data changes.