### PR TITLE
Possible fix for duplicate on cross listed courses

### DIFF
--- a/app/course/[id]/page.tsx
+++ b/app/course/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
 import Link from "next/link";
 import {
   coursesApi,
+  mergeCrossListedCourseOfferings,
   type Activity,
   type Section,
   type Instructor,
@@ -378,7 +379,8 @@ export default function CoursePage() {
       try {
         setIsLoading(true);
         const data = await coursesApi.getCoursesByCode(courseCode);
-        const sorted = [...data].sort((a, b) => {
+        const merged = mergeCrossListedCourseOfferings(data);
+        const sorted = [...merged].sort((a, b) => {
           const ao = TERM_ORDER[a.term?.toUpperCase?.() || ""] ?? 999;
           const bo = TERM_ORDER[b.term?.toUpperCase?.() || ""] ?? 999;
           if (ao !== bo) return ao - bo;
@@ -402,14 +404,27 @@ export default function CoursePage() {
   useEffect(() => {
     async function fetchInstructors() {
       if (!selectedOffering?.id) return;
+      const courseIds =
+        selectedOffering.sourceCourseIds?.length &&
+        selectedOffering.sourceCourseIds.length > 0
+          ? selectedOffering.sourceCourseIds
+          : [selectedOffering.id];
+      const sectionIdToCanonical = selectedOffering.sectionIdToCanonical;
       try {
-        const instructorsData = await coursesApi.getInstructorsByCourseId(
-          selectedOffering.id,
+        const batches = await Promise.all(
+          courseIds.map((id) => coursesApi.getInstructorsByCourseId(id)),
         );
         const instructorsMap: Record<string, Instructor> = {};
-        instructorsData.forEach((instructor) => {
-          instructorsMap[instructor.section_id] = instructor;
-        });
+        for (const instructorsData of batches) {
+          for (const instructor of instructorsData) {
+            const sid =
+              sectionIdToCanonical?.[instructor.section_id] ??
+              instructor.section_id;
+            if (!instructorsMap[sid]) {
+              instructorsMap[sid] = instructor;
+            }
+          }
+        }
         setInstructorsBySection(instructorsMap);
       } catch (err) {
         console.error("Failed to fetch instructors:", err);
@@ -418,7 +433,7 @@ export default function CoursePage() {
     }
 
     fetchInstructors();
-  }, [selectedOffering?.id]);
+  }, [selectedOffering]);
 
   useEffect(() => {
     async function fetchReviews() {

--- a/lib/api/courses.ts
+++ b/lib/api/courses.ts
@@ -126,8 +126,100 @@ export const formatCourseCode = (code: string): string => {
   return code.replace(/([A-Za-z]+)(\d+)/, "$1 $2")
 }
 
-const normalizeCourseCodeKey = (code: string): string =>
+export const normalizeCourseCodeKey = (code: string): string =>
   code.replace(/\s+/g, "").toUpperCase()
+
+const normalizeTermKey = (term: string): string => (term || "").trim().toUpperCase()
+
+/**
+ * Merges GET /courses/{code} rows that represent the same offering (e.g. cross-listed
+ * duplicates): same normalized course code and term. Sections are merged by section
+ * letter; activities deduped by id. Instructor fetches can use sourceCourseIds and
+ * sectionIdToCanonical to combine /instructors/{courseId} payloads.
+ */
+export function mergeCrossListedCourseOfferings(
+  offerings: CourseOffering[],
+): CourseOffering[] {
+  const groups = new Map<string, CourseOffering[]>()
+  for (const o of offerings) {
+    const key = `${normalizeCourseCodeKey(o.code || "")}|${normalizeTermKey(o.term)}`
+    const list = groups.get(key)
+    if (list) list.push(o)
+    else groups.set(key, [o])
+  }
+
+  const merged: CourseOffering[] = []
+
+  for (const group of groups.values()) {
+    group.sort((a, b) => a.id.localeCompare(b.id))
+    const primary = group[0]!
+
+    if (group.length === 1) {
+      merged.push({
+        ...primary,
+        sections: primary.sections?.map((s) => ({ ...s })) ?? [],
+        sourceCourseIds: [primary.id],
+      })
+      continue
+    }
+
+    const byLetter = new Map<string, Section[]>()
+    for (const o of group) {
+      for (const s of o.sections ?? []) {
+        const L = (s.letter || "").trim().toUpperCase()
+        const arr = byLetter.get(L)
+        if (arr) arr.push(s)
+        else byLetter.set(L, [s])
+      }
+    }
+
+    const sectionIdToCanonical: Record<string, string> = {}
+    const mergedSections: Section[] = []
+
+    for (const L of [...byLetter.keys()].sort((a, b) => a.localeCompare(b))) {
+      const secs = byLetter.get(L)!
+      secs.sort((a, b) => a.id.localeCompare(b.id))
+      const canonical = secs[0]!
+      for (const s of secs) {
+        sectionIdToCanonical[s.id] = canonical.id
+      }
+
+      const activitiesById = new Map<string, Activity>()
+      for (const s of secs) {
+        for (const a of s.activities ?? []) {
+          activitiesById.set(a.id, {
+            ...a,
+            section_id: canonical.id,
+          })
+        }
+      }
+
+      mergedSections.push({
+        ...canonical,
+        id: canonical.id,
+        course_id: primary.id,
+        letter: canonical.letter,
+        activities: [...activitiesById.values()],
+      })
+    }
+
+    mergedSections.sort((a, b) =>
+      (a.letter || "").localeCompare(b.letter || "", undefined, {
+        numeric: true,
+      }),
+    )
+
+    merged.push({
+      ...primary,
+      id: primary.id,
+      sections: mergedSections,
+      sourceCourseIds: group.map((g) => g.id),
+      sectionIdToCanonical,
+    })
+  }
+
+  return merged
+}
 
 const dedupeCoursesByCode = (courses: Course[]): Course[] => {
   const seen = new Set<string>()
@@ -196,6 +288,10 @@ export interface CourseOffering {
   faculty: string
   term: string
   sections: Section[]
+  /** Course ids merged into this row (cross-listed); used to load instructors from each. */
+  sourceCourseIds?: string[]
+  /** Maps raw section ids from the API to the canonical section id used after merge. */
+  sectionIdToCanonical?: Record<string, string>
 }
 
 export interface CoursesByCodeResponse {


### PR DESCRIPTION
- GET /courses/{code} can return several rows for the same normalized course code and term (e.g. cross-listing), and the page drew one term tab per array item, so labels like “Fall” repeated.
- Added mergeCrossListedCourseOfferings in lib/api/courses.ts to group by normalized code + term, merge sections by letter, and dedupe activities by id.
- CourseOffering now optionally carries sourceCourseIds, and sectionIdToCanonical, so merged rows still know which backend course ids and section ids belong together.
- The course page loads instructors with Promise.all over sourceCourseIds and maps section_id through sectionIdToCanonical so one merged section still shows the right professor.